### PR TITLE
removed semicolon after class ending brace. fixes compilation with scala's java compiler

### DIFF
--- a/src/org/andengine/opengl/texture/atlas/bitmap/source/decorator/shape/RectangleBitmapTextureAtlasSourceDecoratorShape.java
+++ b/src/org/andengine/opengl/texture/atlas/bitmap/source/decorator/shape/RectangleBitmapTextureAtlasSourceDecoratorShape.java
@@ -56,4 +56,4 @@ public class RectangleBitmapTextureAtlasSourceDecoratorShape implements IBitmapT
 	// ===========================================================
 	// Inner and Anonymous Classes
 	// ===========================================================
-};
+}


### PR DESCRIPTION
really small fix but having a semicolon after class declarations last brace like

class Something {
  // class here
};

 ^ this semi-colon breaks Scala's java-compiler. It gives:

error: illegal start of type declaration
[INFO] };
[INFO]  ^
[ERROR] one error found

There was just one occurrence in AndEngine and now it compiles fine on scala compiler.
