### PR TITLE
Revert "Made ConcurrentShiftQueue use java internal method of copying an...

### DIFF
--- a/src/org/andengine/util/list/ConcurrentShiftQueue.java
+++ b/src/org/andengine/util/list/ConcurrentShiftQueue.java
@@ -127,7 +127,9 @@ public class ConcurrentShiftQueue<T> implements IQueue<T> {
 			} else {
 				/* Increase array size. */
 				final int newCapacity = (currentCapacity * 3) / 2 + 1;
-				this.mItems = Arrays.copyOf(this.mItems, newCapacity);
+				final Object newItems[] = new Object[newCapacity];
+				System.arraycopy(this.mItems, 0, newItems, 0, currentCapacity);
+				this.mItems = newItems;
 			}
 		}
 	}


### PR DESCRIPTION
... Array, for eventually better performance."

This reverts commit c35860c15fd1b061731a6f5d211974deb823bfe1.
It broke AE on pre API-9 devices (froyo and less)
