### PR TITLE
Use System.arraycopy instead of Arrays.copyOf to get compatibility back ...

### DIFF
--- a/src/org/andengine/util/list/FloatArrayList.java
+++ b/src/org/andengine/util/list/FloatArrayList.java
@@ -1,6 +1,5 @@
 package org.andengine.util.list;
 
-import java.util.Arrays;
 
 /**
  * (c) Zynga 2012
@@ -111,7 +110,9 @@ public class FloatArrayList implements IFloatList {
 		if(currentCapacity < pCapacity) {
 			/* Increase array size. */
 			final int newCapacity = (currentCapacity * 3) / 2 + 1;
-			this.mItems = Arrays.copyOf(this.mItems, newCapacity);
+			final float newItems[] = new float[newCapacity];
+			System.arraycopy(this.mItems, 0, newItems, 0, currentCapacity);
+			this.mItems = newItems;
 		}
 	}
 


### PR DESCRIPTION
...with Froyo devices (API Level 8)
