### PR TITLE
Fix for broken Camera rotation calculations

### DIFF
--- a/src/org/andengine/engine/camera/Camera.java
+++ b/src/org/andengine/engine/camera/Camera.java
@@ -397,7 +397,7 @@ public class Camera implements IUpdateHandler {
 	private void applySceneRotation(final float[] pCameraSceneCoordinates) {
 		final float rotation = this.mRotation;
 		if(rotation != 0) {
-			MathUtils.rotateAroundCenter(pCameraSceneCoordinates, -rotation, this.getCenterX(), this.getCenterY());
+			MathUtils.rotateAroundCenter(pCameraSceneCoordinates, rotation, this.getCenterX(), this.getCenterY());
 		}
 	}
 
@@ -407,7 +407,7 @@ public class Camera implements IUpdateHandler {
 			Camera.VERTICES_TMP[Constants.VERTEX_INDEX_X] = pCameraSceneTouchEvent.getX();
 			Camera.VERTICES_TMP[Constants.VERTEX_INDEX_Y] = pCameraSceneTouchEvent.getY();
 
-			MathUtils.rotateAroundCenter(Camera.VERTICES_TMP, -rotation, this.getCenterX(), this.getCenterY());
+			MathUtils.rotateAroundCenter(Camera.VERTICES_TMP, rotation, this.getCenterX(), this.getCenterY());
 
 			pCameraSceneTouchEvent.set(Camera.VERTICES_TMP[Constants.VERTEX_INDEX_X], Camera.VERTICES_TMP[Constants.VERTEX_INDEX_Y]);
 		}


### PR DESCRIPTION
Due to some unfortunate '-' sign CameraScene/HUD were not working correctly when camera was rotated. This commit fixes this problem.

Anyone willing to verify this problem can apply the following on AndEngineExamples project, and run AnalogOnScreenControlExample:

``` diff
diff --git a/src/org/andengine/examples/AnalogOnScreenControlExample.java b/src/org/andengine/examples/AnalogOnScreenControlExample.java
index b275d5e..997bc7c 100644
--- a/src/org/andengine/examples/AnalogOnScreenControlExample.java
+++ b/src/org/andengine/examples/AnalogOnScreenControlExample.java
@@ -1,6 +1,7 @@
 package org.andengine.examples;

 import org.andengine.engine.camera.Camera;
+import org.andengine.engine.camera.hud.HUD;
 import org.andengine.engine.camera.hud.controls.AnalogOnScreenControl;
 import org.andengine.engine.camera.hud.controls.AnalogOnScreenControl.IAnalogOnScreenControlListener;
 import org.andengine.engine.camera.hud.controls.BaseOnScreenControl;
@@ -119,7 +120,11 @@ public class AnalogOnScreenControlExample extends SimpleBaseGameActivity {
                analogOnScreenControl.getControlKnob().setScale(1.25f);
                analogOnScreenControl.refreshControlKnobPosition();

-               scene.setChildScene(analogOnScreenControl);
+               HUD hud = new HUD();
+               mCamera.setHUD(hud);
+               mCamera.setRotation(30);
+               hud.setChildScene(analogOnScreenControl);

                return scene;
        }
```
