### PR TITLE
Changed StrokeFont's drawLetter definition to match Font. 

### DIFF
--- a/src/org/andengine/opengl/font/StrokeFont.java
+++ b/src/org/andengine/opengl/font/StrokeFont.java
@@ -76,7 +76,7 @@ public class StrokeFont extends Font {
 		this.mTextBounds.inset(inset, inset);
 	}
 
-	protected void drawLetter(final String pCharacterAsString, final int pLeft, final int pTop) {
+	protected void drawLetter(final String pCharacterAsString, final float pLeft, final float pTop) {
 		if(!this.mStrokeOnly) {
 			super.drawLetter(pCharacterAsString, pLeft, pTop);
 		}


### PR DESCRIPTION
The difference caused StrokeFonts to render as normal Fonts.

Hopefully I have performed this pull request correctly, if not let me know! AndEngine is my first experience using git and I wasn't sure if I should make a new pull request for such a tiny bug.
