### PR TITLE
Bugfix: don't allocate 4 times the requested memory

### DIFF
--- a/src/org/andengine/opengl/util/BufferUtils.java
+++ b/src/org/andengine/opengl/util/BufferUtils.java
@@ -80,6 +80,10 @@ public class BufferUtils {
 	// Methods
 	// ===========================================================
 
+	/**
+	 * @param pCapacity Capacity of the buffer in bytes
+	 * @return
+	 */
 	public static ByteBuffer allocateDirectByteBuffer(final int pCapacity) {
 		if(BufferUtils.WORKAROUND_BYTEBUFFER_ALLOCATE_DIRECT) {
 			return BufferUtils.jniAllocateDirect(pCapacity);


### PR DESCRIPTION
I ran into an issue (out-of-memory) when allocating large buffer objects, that worked on earlier version of andengine.

Problem was that BufferUtils.allocateDirectByteBuffer() allocated more memory than needed. All the callers assumed how many bytes to allocate, but this method allocated memory for that number of floats.
