### PR TITLE
Prevent potential for Endless Loop in TimerHandler

### DIFF
--- a/src/org/andengine/engine/handler/timer/TimerHandler.java
+++ b/src/org/andengine/engine/handler/timer/TimerHandler.java
@@ -33,6 +33,10 @@ public class TimerHandler implements IUpdateHandler {
 	}
 
 	public TimerHandler(final float pTimerSeconds, final boolean pAutoReset, final ITimerCallback pTimerCallback) {
+		if(pTimerSeconds <= 0){
+			throw new IllegalStateException("pTimerSeconds must be >= 0!");
+		}
+		
 		this.mTimerSeconds = pTimerSeconds;
 		this.mAutoReset = pAutoReset;
 		this.mTimerCallback = pTimerCallback;


### PR DESCRIPTION
If a TimerHandler is constructed with pTimerSeconds <= 0 an endless loop will be created in the onUpdate() while loop because in the code fragment

while(this.mTimerSecondsElapsed >= this.mTimerSeconds) {..}

'this.mTimerSecondsElapsed' will always be greater than 'this.mTimerSeconds'.

The same problem could occur if setTimerSeconds(...) is called with pTimerSeconds <= 0;

Another way to fix this is to add an additional test for mTimerSeconds <= 0 in the onUpdate method, but that will add unnecessary overhead.
