### PR TITLE
Edit README to include instructions for building with IntelliJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@
 ## Building
 
  * AndEngine has to be build with ADT-17 or higher!
+ * Building with IntelliJ IDEA
+ 	* AndEngine relies on ADT to auto-generate a "BuildConfig" class. IntelliJ IDEA (as of 11.1.1) has not fully integrated with ADT-17+. In order to build AndEngine with IntelliJ IDEA, you can simply add the following class yourself in the root package (org.andengine): 
+ 	
+ 	```java
+ 	package org.andengine;
+
+    public final class BuildConfig {
+    
+    public final static boolean DEBUG = true;
+    
+    }
+    ```
+
 
 ## Branches
 


### PR DESCRIPTION
- Building AndEngine relies on ADT 17+ for generating the BuildConfig class. I've edited the README to include simple, temporary work-around for building with IntelliJ.
