### PR TITLE
Fix race condition in SoundManager/SoundFactory

### DIFF
--- a/src/org/andengine/audio/sound/SoundFactory.java
+++ b/src/org/andengine/audio/sound/SoundFactory.java
@@ -57,24 +57,30 @@ public class SoundFactory {
 	// ===========================================================
 
 	public static Sound createSoundFromPath(final SoundManager pSoundManager, final String pPath) throws IOException {
-		final int soundID = pSoundManager.getSoundPool().load(pPath, 1);
-		final Sound sound = new Sound(pSoundManager, soundID);
-		pSoundManager.add(sound);
-		return sound;
+		synchronized(pSoundManager) {
+			final int soundID = pSoundManager.getSoundPool().load(pPath, 1);
+			final Sound sound = new Sound(pSoundManager, soundID);
+			pSoundManager.add(sound);
+			return sound;
+		}
 	}
 
 	public static Sound createSoundFromAsset(final SoundManager pSoundManager, final Context pContext, final String pAssetPath) throws IOException {
-		final int soundID = pSoundManager.getSoundPool().load(pContext.getAssets().openFd(SoundFactory.sAssetBasePath + pAssetPath), 1);
-		final Sound sound = new Sound(pSoundManager, soundID);
-		pSoundManager.add(sound);
-		return sound;
+		synchronized(pSoundManager) {
+			final int soundID = pSoundManager.getSoundPool().load(pContext.getAssets().openFd(SoundFactory.sAssetBasePath + pAssetPath), 1);
+			final Sound sound = new Sound(pSoundManager, soundID);
+			pSoundManager.add(sound);
+			return sound;
+		}
 	}
 
 	public static Sound createSoundFromResource(final SoundManager pSoundManager, final Context pContext, final int pSoundResID) {
-		final int soundID = pSoundManager.getSoundPool().load(pContext, pSoundResID, 1);
-		final Sound sound = new Sound(pSoundManager, soundID);
-		pSoundManager.add(sound);
-		return sound;
+		synchronized(pSoundManager) {
+			final int soundID = pSoundManager.getSoundPool().load(pContext, pSoundResID, 1);
+			final Sound sound = new Sound(pSoundManager, soundID);
+			pSoundManager.add(sound);
+			return sound;
+		}
 	}
 
 	public static Sound createSoundFromFile(final SoundManager pSoundManager, final File pFile) throws IOException {
@@ -82,17 +88,21 @@ public class SoundFactory {
 	}
 
 	public static Sound createSoundFromAssetFileDescriptor(final SoundManager pSoundManager, final AssetFileDescriptor pAssetFileDescriptor) {
-		final int soundID = pSoundManager.getSoundPool().load(pAssetFileDescriptor, 1);
-		final Sound sound = new Sound(pSoundManager, soundID);
-		pSoundManager.add(sound);
-		return sound;
+		synchronized(pSoundManager) {
+			final int soundID = pSoundManager.getSoundPool().load(pAssetFileDescriptor, 1);
+			final Sound sound = new Sound(pSoundManager, soundID);
+			pSoundManager.add(sound);
+			return sound;
+		}
 	}
 
 	public static Sound createSoundFromFileDescriptor(final SoundManager pSoundManager, final FileDescriptor pFileDescriptor, final long pOffset, final long pLength) throws IOException {
-		final int soundID = pSoundManager.getSoundPool().load(pFileDescriptor, pOffset, pLength, 1);
-		final Sound sound = new Sound(pSoundManager, soundID);
-		pSoundManager.add(sound);
-		return sound;
+		synchronized(pSoundManager) {
+			final int soundID = pSoundManager.getSoundPool().load(pFileDescriptor, pOffset, pLength, 1);
+			final Sound sound = new Sound(pSoundManager, soundID);
+			pSoundManager.add(sound);
+			return sound;
+		}
 	}
 
 	// ===========================================================

--- a/src/org/andengine/audio/sound/SoundManager.java
+++ b/src/org/andengine/audio/sound/SoundManager.java
@@ -81,7 +81,7 @@ public class SoundManager extends BaseAudioManager<Sound> implements OnLoadCompl
 	}
 	
 	@Override
-	public void onLoadComplete(final SoundPool pSoundPool, final int pSoundID, final int pStatus) {
+	public synchronized void onLoadComplete(final SoundPool pSoundPool, final int pSoundID, final int pStatus) {
 		if(pStatus == SoundManager.SOUND_STATUS_OK) {
 			final Sound sound = this.mSoundMap.get(pSoundID);
 			if(sound == null) {


### PR DESCRIPTION
When short files were used SoundManager::onLoadComplete() was called
before Sound was added to mSoundMap via SoundManager::add()

bug: https://github.com/nicolasgramlich/AndEngine/issues/78
