### PR TITLE
Fix broken AStarPathFinder

### DIFF
--- a/src/org/andengine/util/algorithm/path/astar/AStarPathFinder.java
+++ b/src/org/andengine/util/algorithm/path/astar/AStarPathFinder.java
@@ -66,7 +66,7 @@ public class AStarPathFinder<T> implements IPathFinder<T> {
 
 		final LongSparseArray<Node> visitedNodes = new LongSparseArray<Node>();
 		final LongSparseArray<Node> openNodes = new LongSparseArray<Node>();
-		final IQueue<Node> sortedOpenNodes = new UniqueQueue<Node>(new SortedQueue<Node>(new ShiftList<Node>()));
+		final IQueue<Node> sortedOpenNodes = new SortedQueue<Node>(new ShiftList<Node>());
 
 		final boolean allowDiagonalMovement = pAllowDiagonal;
 


### PR DESCRIPTION
One of the previous refactoring rounds messed up sortedOpenNodes queue
to actually be unique, instead of sorted.

I was wondering for a long time if this is only me, or if this is really wrong. Strange, that no one is complaing... But I am quite sure that sortedOpenNodes really should be sorted :)
