### PR TITLE
Added dithering enable/disable methods to RenderOptions

### DIFF
--- a/src/org/andengine/engine/options/RenderOptions.java
+++ b/src/org/andengine/engine/options/RenderOptions.java
@@ -17,6 +17,7 @@ public class RenderOptions {
 	// ===========================================================
 
 	private boolean mMultiSampling = false;
+	private boolean mDithering = false;
 
 	// ===========================================================
 	// Constructors
@@ -32,6 +33,14 @@ public class RenderOptions {
 
 	public void setMultiSampling(final boolean pMultiSampling) {
 		this.mMultiSampling = pMultiSampling;
+	}
+
+	public boolean isDithering() {
+		return this.mDithering;
+	}
+
+	public void setDithering(final boolean pDithering) {
+		this.mDithering = pDithering;
 	}
 
 	// ===========================================================

--- a/src/org/andengine/opengl/util/GLState.java
+++ b/src/org/andengine/opengl/util/GLState.java
@@ -153,7 +153,7 @@ public class GLState {
 		this.mCurrentSourceBlendMode = -1;
 		this.mCurrentDestinationBlendMode = -1;
 
-		this.enableDither();
+		setDitherEnabled(pRenderOptions.isDithering());
 		this.enableDepthTest();
 
 		this.disableBlend();

--- a/src/org/andengine/opengl/view/EngineRenderer.java
+++ b/src/org/andengine/opengl/view/EngineRenderer.java
@@ -65,7 +65,6 @@ public class EngineRenderer implements GLSurfaceView.Renderer {
 //			GLES20.glEnable(GLES20.GL_POINT_SMOOTH);
 //			GLES20.glHint(GLES20.GL_POINT_SMOOTH_HINT, GLES20.GL_NICEST);
 
-			this.mGLState.disableDither();
 			this.mGLState.disableDepthTest();
 
 			this.mGLState.enableBlend();


### PR DESCRIPTION
Added setDithering() and isDithering() methods to RenderOptions

to be used like this:

``` java
    public EngineOptions onCreateEngineOptions() {
        final Camera camera = new Camera(0, 0, Consts.CAMERA_WIDTH, Consts.CAMERA_HEIGHT);
        EngineOptions engopts = new EngineOptions(true, ScreenOrientation.LANDSCAPE_FIXED, new RatioResolutionPolicy(Consts.CAMERA_WIDTH, Consts.CAMERA_HEIGHT), camera);
        engopts.getRenderOptions().setDithering(true); // this is new
        return engopts;
    }
```
