### PR TITLE
Callback can now be fired when Entity gets detached by EntityDetachRunnablePoolItem

### DIFF
--- a/src/org/andengine/util/adt/pool/EntityDetachRunnablePoolItem.java
+++ b/src/org/andengine/util/adt/pool/EntityDetachRunnablePoolItem.java
@@ -1,6 +1,7 @@
 package org.andengine.util.adt.pool;
 
 import org.andengine.entity.IEntity;
+import org.andengine.util.call.Callback;
 
 /**
  * (c) 2010 Nicolas Gramlich 
@@ -19,6 +20,7 @@ public class EntityDetachRunnablePoolItem extends RunnablePoolItem {
 	// ===========================================================
 
 	protected IEntity mEntity;
+	protected Callback<IEntity> mCallback;
 
 	// ===========================================================
 	// Constructors
@@ -32,6 +34,14 @@ public class EntityDetachRunnablePoolItem extends RunnablePoolItem {
 		this.mEntity = pEntity;
 	}
 
+	/**
+	 * Sets up a callback which will get called right after detaching entity
+	 * @param pCallback gets called right after detaching entity; if null nothing will be called
+	 */
+	public void setCallback(final Callback<IEntity> pCallback) {
+		this.mCallback = pCallback;
+	}
+
 	// ===========================================================
 	// Methods for/from SuperClass/Interfaces
 	// ===========================================================
@@ -39,6 +49,9 @@ public class EntityDetachRunnablePoolItem extends RunnablePoolItem {
 	@Override
 	public void run() {
 		this.mEntity.detachSelf();
+		if (mCallback != null) {
+			mCallback.onCallback(mEntity);
+		}
 	}
 
 	// ===========================================================

--- a/src/org/andengine/util/adt/pool/EntityDetachRunnablePoolUpdateHandler.java
+++ b/src/org/andengine/util/adt/pool/EntityDetachRunnablePoolUpdateHandler.java
@@ -1,6 +1,7 @@
 package org.andengine.util.adt.pool;
 
 import org.andengine.entity.IEntity;
+import org.andengine.util.call.Callback;
 
 /**
  * (c) 2010 Nicolas Gramlich
@@ -56,8 +57,18 @@ public class EntityDetachRunnablePoolUpdateHandler extends RunnablePoolUpdateHan
 	// ===========================================================
 
 	public void scheduleDetach(final IEntity pEntity) {
+		scheduleDetach(pEntity, null);
+	}
+
+	/**
+	 * Schedules detach of given entity
+	 * @param pEntity will be safely detached
+	 * @param pCallback will be called when this entity gets detached
+	 */
+	public void scheduleDetach(final IEntity pEntity, final Callback<IEntity> pCallback) {
 		final EntityDetachRunnablePoolItem entityDetachRunnablePoolItem = this.obtainPoolItem();
 		entityDetachRunnablePoolItem.setEntity(pEntity);
+		entityDetachRunnablePoolItem.setCallback(pCallback);
 		this.postPoolItem(entityDetachRunnablePoolItem);
 	}
 


### PR DESCRIPTION
Right after entity gets detached via EntityDetachRunnablePoolItem
a callback will be fired if it was previously registered via setCallback().

New schedule() version was added to EntityDetachRunnablePoolUpdateHandler-
it allows specifying a callback to be called after entity gets detached.
