### PR TITLE
A little bit more verbose Excetpion when GLES20Fix fails ultimately

### DIFF
--- a/src/org/andengine/opengl/GLES20Fix.java
+++ b/src/org/andengine/opengl/GLES20Fix.java
@@ -36,7 +36,7 @@ public class GLES20Fix {
 			if(loadLibrarySuccess) {
 				WORKAROUND_MISSING_GLES20_METHODS = true;
 			} else {
-				throw new AndEngineRuntimeException();
+				throw new AndEngineRuntimeException("Inherently incompatible device detected.");
 			}
 		} else {
 			WORKAROUND_MISSING_GLES20_METHODS = false;


### PR DESCRIPTION
Some users reported ExceptionInInitializerError which might come
from this not too obscure exception :)
