### PR TITLE
Fixed a game-crashing exception

### DIFF
--- a/src/org/andengine/entity/Entity.java
+++ b/src/org/andengine/entity/Entity.java
@@ -1397,8 +1397,7 @@ public class Entity implements IEntity {
 
 		if((this.mChildren != null) && !this.mChildrenIgnoreUpdate) {
 			final SmartList<IEntity> entities = this.mChildren;
-			final int entityCount = entities.size();
-			for(int i = 0; i < entityCount; i++) {
+			for(int i = 0; i < entities.size(); i++) {
 				entities.get(i).onUpdate(pSecondsElapsed);
 			}
 		}


### PR DESCRIPTION
The Entity.onManagedUpdate() method caches the size of its mChildren array before iterating through it and updating its children. There are multiple valid reasons for these children to remove themselves during their update. However, if one does, its parent will iterate out of bounds, because its mChildren array will be shorter than the cached value says it is.

This change removes the cached value and instead has the loop recheck the array's size on every iteration. Yes, this is slightly slower, but given the nature of this loop, it doesn't make sense to rely on the array staying the same length.

See http://www.andengine.org/forums/gles2/removing-an-entity-when-a-modifier-finishes-t7999.html for a more in-depth discussion.
