### PR TITLE
Added Text align and Fixed the wrong transformation center of RetangularShape

### DIFF
--- a/src/org/andengine/entity/shape/RectangularShape.java
+++ b/src/org/andengine/entity/shape/RectangularShape.java
@@ -56,12 +56,14 @@ public abstract class RectangularShape extends Shape implements IAreaShape {
 	@Override
 	public void setWidth(final float pWidth) {
 		this.mWidth = pWidth;
+		this.reset();
 		this.onUpdateVertices();
 	}
 
 	@Override
 	public void setHeight(final float pHeight) {
 		this.mHeight = pHeight;
+		this.reset();
 		this.onUpdateVertices();
 	}
 
@@ -69,6 +71,7 @@ public abstract class RectangularShape extends Shape implements IAreaShape {
 	public void setSize(final float pWidth, final float pHeight) {
 		this.mWidth = pWidth;
 		this.mHeight = pHeight;
+		this.reset();
 		this.onUpdateVertices();
 	}
 

--- a/src/org/andengine/entity/text/Text.java
+++ b/src/org/andengine/entity/text/Text.java
@@ -63,6 +63,8 @@ public class Text extends RectangularShape {
 
 	protected final IFont mFont;
 
+	protected float mBaseX;
+	protected float mBaseY;
 	protected float mLineWidthMaximum;
 	protected float mLineAlignmentWidth;
 
@@ -149,6 +151,8 @@ public class Text extends RectangularShape {
 	public Text(final float pX, final float pY, final IFont pFont, final CharSequence pText, final int pCharactersMaximum, final TextOptions pTextOptions, final ITextVertexBufferObject pTextVertexBufferObject, final ShaderProgram pShaderProgram) {
 		super(pX, pY, 0, 0, pShaderProgram);
 
+		this.mBaseX = pX;
+		this.mBaseY = pY;
 		this.mFont = pFont;
 		this.mTextOptions = pTextOptions;
 		this.mCharactersMaximum = pCharactersMaximum;
@@ -220,6 +224,22 @@ public class Text extends RectangularShape {
 		this.mScaleCenterX = this.mRotationCenterX;
 		this.mScaleCenterY = this.mRotationCenterY;
 
+		switch (mTextOptions.mHorizontalAlign) {
+			case LEFT:
+				super.mX = this.mBaseX;
+				super.mY = this.mBaseY;
+				break;
+
+			case RIGHT:
+				super.mX = this.mBaseX - this.mWidth;
+				super.mY = this.mBaseY;
+				break;
+
+			case CENTER:
+				super.mX = this.mBaseX - this.mWidth / 2;
+				super.mY = this.mBaseY;
+				break;
+		}
 		this.onUpdateVertices();
 	}
 


### PR DESCRIPTION
Hi, Nicolas!
I added the horizontal align feature to Text.
Also when RectangularShape is scaled, the transformation doesn't work correctly.
Because when RectangularShape is resized, the transformation centers such as scale center, rotation center, skew center will not be recalculated.
I fixed this problem.
