### PR TITLE
Allow 8-pos in Direction

### DIFF
--- a/src/org/anddev/andengine/util/path/Direction.java
+++ b/src/org/anddev/andengine/util/path/Direction.java
@@ -1,7 +1,7 @@
 package org.anddev.andengine.util.path;
 
 /**
- * (c) 2010 Nicolas Gramlich 
+ * (c) 2010 Nicolas Gramlich
  * (c) 2011 Zynga Inc.
  * 
  * @author Nicolas Gramlich
@@ -12,7 +12,14 @@ public enum Direction {
 	// Elements
 	// ===========================================================
 
-	UP(0, -1), DOWN(0, 1), LEFT(-1, 0), RIGHT(1, 0);
+	UP(0, -1),
+	DOWN(0, 1),
+	LEFT(-1, 0),
+	RIGHT(1, 0),
+	UP_LEFT(-1, -1),
+	UP_RIGHT(1, -1),
+	DOWN_LEFT(-1, 1),
+	DOWN_RIGHT(1, 1);
 
 	// ===========================================================
 	// Constants
@@ -35,25 +42,50 @@ public enum Direction {
 	}
 
 	public static Direction fromDelta(final int pDeltaX, final int pDeltaY) {
-		if(pDeltaX == 0) {
-			if(pDeltaY == 1) {
-				return DOWN;
-			} else if(pDeltaY == -1) {
-				return UP;
-			}
-		} else if (pDeltaY == 0) {
-			if(pDeltaX == 1) {
-				return RIGHT;
-			} else if(pDeltaX == -1) {
-				return LEFT;
-			}
+		switch(pDeltaX) {
+			case -1:
+				switch(pDeltaY) {
+					case -1:
+						return UP_LEFT;
+					case 0:
+						return LEFT;
+					case 1:
+						return DOWN_LEFT;
+				}
+				break;
+			case 0:
+				switch(pDeltaY) {
+					case -1:
+						return UP;
+					case 1:
+						return DOWN;
+				}
+				break;
+			case 1:
+				switch(pDeltaY) {
+					case -1:
+						return UP_RIGHT;
+					case 0:
+						return RIGHT;
+					case 1:
+						return DOWN_RIGHT;
+				}
+				break;
 		}
-		throw new IllegalArgumentException();
+		throw new IllegalArgumentException("Unexpected deltaX: '" + pDeltaX + "' deltaY: '" + pDeltaY + "'.");
 	}
 
 	// ===========================================================
 	// Getter & Setter
 	// ===========================================================
+
+	public boolean isHorizontal() {
+		return this.mDeltaY == 0;
+	}
+
+	public boolean isVertical() {
+		return this.mDeltaX == 0;
+	}
 
 	public int getDeltaX() {
 		return this.mDeltaX;
@@ -61,6 +93,72 @@ public enum Direction {
 
 	public int getDeltaY() {
 		return this.mDeltaY;
+	}
+
+	public Direction rotateLeft() {
+		switch(this) {
+			case UP:
+				return LEFT;
+			case UP_RIGHT:
+				return UP_LEFT;
+			case RIGHT:
+				return UP;
+			case DOWN_RIGHT:
+				return UP_RIGHT;
+			case DOWN:
+				return UP;
+			case DOWN_LEFT:
+				return DOWN_RIGHT;
+			case LEFT:
+				return DOWN;
+			case UP_LEFT:
+				return DOWN_LEFT;
+		}
+		throw new IllegalArgumentException();
+	}
+
+	public Direction rotateRight() {
+		switch(this) {
+			case UP:
+				return RIGHT;
+			case UP_RIGHT:
+				return DOWN_RIGHT;
+			case RIGHT:
+				return DOWN;
+			case DOWN_RIGHT:
+				return DOWN_LEFT;
+			case DOWN:
+				return LEFT;
+			case DOWN_LEFT:
+				return UP_LEFT;
+			case LEFT:
+				return UP;
+			case UP_LEFT:
+				return UP_RIGHT;
+		}
+		throw new IllegalArgumentException();
+	}
+
+	public Direction opposite() {
+		switch(this) {
+			case UP:
+				return DOWN;
+			case UP_RIGHT:
+				return DOWN_LEFT;
+			case RIGHT:
+				return LEFT;
+			case DOWN_RIGHT:
+				return UP_LEFT;
+			case DOWN:
+				return UP;
+			case DOWN_LEFT:
+				return UP_RIGHT;
+			case LEFT:
+				return RIGHT;
+			case UP_LEFT:
+				return DOWN_RIGHT;
+		}
+		throw new IllegalArgumentException();
 	}
 
 	// ===========================================================
@@ -75,3 +173,4 @@ public enum Direction {
 	// Inner and Anonymous Classes
 	// ===========================================================
 }
+


### PR DESCRIPTION
This patch allows for 8 directions (instead of 4). The previous version of the Direction class caused IllegalArgumentException when used with AStarPathFinder and diagonal movement.
