### PR TITLE
Restrict rotation to < 360°

### DIFF
--- a/src/org/anddev/andengine/entity/Entity.java
+++ b/src/org/anddev/andengine/entity/Entity.java
@@ -238,7 +238,7 @@ public class Entity implements IEntity {
 
 	@Override
 	public void setRotation(final float pRotation) {
-		this.mRotation = pRotation;
+		this.mRotation = pRotation % 360;
 		this.mLocalToParentTransformationDirty = true;
 		this.mParentToLocalTransformationDirty = true;
 	}


### PR DESCRIPTION
By using RotationByModifier several times the absolute value of an Entity's rotation can grow unbounded. This should not not happen and when calling getRotation() applications may assume that the returned value lies in the interval [-360°, 360°]. I don't see why it would be useful to support a larger interval. It could even be restricted to [0, 360"] without significant loss of functionality.