### PR TITLE
Fix for skipping Runnables in RunnableHandler

### DIFF
--- a/src/org/andengine/engine/handler/runnable/RunnableHandler.java
+++ b/src/org/andengine/engine/handler/runnable/RunnableHandler.java
@@ -39,9 +39,8 @@ public class RunnableHandler implements IUpdateHandler {
 		final ArrayList<Runnable> runnables = this.mRunnables;
 		final int runnableCount = runnables.size();
 		for(int i = runnableCount - 1; i >= 0; i--) {
-			runnables.get(i).run();
+			runnables.remove(i).run();
 		}
-		runnables.clear();
 	}
 
 	@Override


### PR DESCRIPTION
Runnables added to mRunnables while walking through mRunnables list
were never run.

I do not see any negative side effects.
