### PR TITLE
AStarPathFinder improvements

### DIFF
--- a/src/org/anddev/andengine/util/path/IPathFinder.java
+++ b/src/org/anddev/andengine/util/path/IPathFinder.java
@@ -16,5 +16,5 @@ public interface IPathFinder<T> {
 	// Fields
 	// ===========================================================
 
-	public Path findPath(final T pEntity, final float pMaxCost, final int pFromTileColumn, final int pFromTileRow, final int pToTileColumn, final int pToTileRow);
+	public Path findPath(final T pEntity, final float pMaxCost, final int pFromTileColumn, final int pFromTileRow, final int pToTileColumn, final int pToTileRow) throws NegativeStepCostException;
 }

--- a/src/org/anddev/andengine/util/path/IPathFinder.java
+++ b/src/org/anddev/andengine/util/path/IPathFinder.java
@@ -16,5 +16,5 @@ public interface IPathFinder<T> {
 	// Fields
 	// ===========================================================
 
-	public Path findPath(final T pEntity, final int pMaxCost, final int pFromTileColumn, final int pFromTileRow, final int pToTileColumn, final int pToTileRow);
+	public Path findPath(final T pEntity, final float pMaxCost, final int pFromTileColumn, final int pFromTileRow, final int pToTileColumn, final int pToTileRow);
 }

--- a/src/org/anddev/andengine/util/path/NegativeStepCostException.java
+++ b/src/org/anddev/andengine/util/path/NegativeStepCostException.java
@@ -1,0 +1,9 @@
+package org.anddev.andengine.util.path;
+
+@SuppressWarnings("serial")
+public class NegativeStepCostException extends Exception {
+	public NegativeStepCostException()
+	{
+		super("Can not handle negative step cost!");
+	}
+}

--- a/src/org/anddev/andengine/util/path/astar/AStarPathFinder.java
+++ b/src/org/anddev/andengine/util/path/astar/AStarPathFinder.java
@@ -96,8 +96,8 @@ public class AStarPathFinder<T> implements IPathFinder<T> {
 
 		int currentDepth = 0;
 		while(currentDepth < maxSearchDepth && !openNodes.isEmpty()) {
-			/* The first Node in the open list is the one with the lowest cost. */
-			final Node current = openNodes.remove(0);
+			/* Get the Node with lowest cost+heuristic. */
+			final Node current = Collections.min(openNodes);
 			if(current == toNode) {
 				break;
 			}
@@ -145,10 +145,6 @@ public class AStarPathFinder<T> implements IPathFinder<T> {
 								neighbor.mExpectedRestCost = aStarHeuristic.getExpectedRestCost(tiledMap, pEntity, neighborTileColumn, neighborTileRow, pToTileColumn, pToTileRow);
 								currentDepth = Math.max(currentDepth, neighbor.setParent(current));
 								openNodes.add(neighbor);
-
-								/* Ensure always the node with the lowest cost+heuristic
-								 * will be used next, simply by sorting. */
-								Collections.sort(openNodes);
 							}
 						}
 					}

--- a/src/org/anddev/andengine/util/path/astar/AStarPathFinder.java
+++ b/src/org/anddev/andengine/util/path/astar/AStarPathFinder.java
@@ -1,7 +1,7 @@
 package org.anddev.andengine.util.path.astar;
 
-import java.util.ArrayList;
 import java.util.PriorityQueue;
+import java.util.TreeSet;
 
 import org.anddev.andengine.util.path.IPathFinder;
 import org.anddev.andengine.util.path.ITiledMap;
@@ -24,7 +24,7 @@ public class AStarPathFinder<T> implements IPathFinder<T> {
 	// Fields
 	// ===========================================================
 
-	private final ArrayList<Node> mVisitedNodes = new ArrayList<Node>();
+	private final TreeSet<Node> mVisitedNodes = new TreeSet<Node>();
 	private final PriorityQueue<Node> mOpenNodes = new PriorityQueue<Node>();
 
 	private final ITiledMap<T> mTiledMap;
@@ -75,7 +75,7 @@ public class AStarPathFinder<T> implements IPathFinder<T> {
 
 		/* Drag some fields to local variables. */
 		final PriorityQueue<Node> openNodes = this.mOpenNodes;
-		final ArrayList<Node> visitedNodes = this.mVisitedNodes;
+		final TreeSet<Node> visitedNodes = this.mVisitedNodes;
 
 		final Node[][] nodes = this.mNodes;
 		final Node fromNode = nodes[pFromTileRow][pFromTileColumn];

--- a/src/org/anddev/andengine/util/path/astar/AStarPathFinder.java
+++ b/src/org/anddev/andengine/util/path/astar/AStarPathFinder.java
@@ -1,7 +1,7 @@
 package org.anddev.andengine.util.path.astar;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.PriorityQueue;
 
 import org.anddev.andengine.util.path.IPathFinder;
 import org.anddev.andengine.util.path.ITiledMap;
@@ -25,7 +25,7 @@ public class AStarPathFinder<T> implements IPathFinder<T> {
 	// ===========================================================
 
 	private final ArrayList<Node> mVisitedNodes = new ArrayList<Node>();
-	private final ArrayList<Node> mOpenNodes = new ArrayList<Node>();
+	private final PriorityQueue<Node> mOpenNodes = new PriorityQueue<Node>();
 
 	private final ITiledMap<T> mTiledMap;
 	private final int mMaxSearchDepth;
@@ -74,7 +74,7 @@ public class AStarPathFinder<T> implements IPathFinder<T> {
 		}
 
 		/* Drag some fields to local variables. */
-		final ArrayList<Node> openNodes = this.mOpenNodes;
+		final PriorityQueue<Node> openNodes = this.mOpenNodes;
 		final ArrayList<Node> visitedNodes = this.mVisitedNodes;
 
 		final Node[][] nodes = this.mNodes;
@@ -98,7 +98,7 @@ public class AStarPathFinder<T> implements IPathFinder<T> {
 		int currentDepth = 0;
 		while(currentDepth < maxSearchDepth && !openNodes.isEmpty()) {
 			/* Get the Node with lowest cost+heuristic. */
-			final Node current = Collections.min(openNodes);
+			final Node current = openNodes.poll();
 			if(current == toNode) {
 				break;
 			}

--- a/src/org/anddev/andengine/util/path/astar/AStarPathFinder.java
+++ b/src/org/anddev/andengine/util/path/astar/AStarPathFinder.java
@@ -66,7 +66,7 @@ public class AStarPathFinder<T> implements IPathFinder<T> {
 	// ===========================================================
 
 	@Override
-	public Path findPath(final T pEntity, final int pMaxCost, final int pFromTileColumn, final int pFromTileRow, final int pToTileColumn, final int pToTileRow) {
+	public Path findPath(final T pEntity, final float pMaxCost, final int pFromTileColumn, final int pFromTileRow, final int pToTileColumn, final int pToTileRow) {
 		final ITiledMap<T> tiledMap = this.mTiledMap;
 		if(tiledMap.isTileBlocked(pEntity, pToTileColumn, pToTileRow)) {
 			return null;

--- a/src/org/anddev/andengine/util/path/astar/AStarPathFinder.java
+++ b/src/org/anddev/andengine/util/path/astar/AStarPathFinder.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 
 import org.anddev.andengine.util.path.IPathFinder;
 import org.anddev.andengine.util.path.ITiledMap;
+import org.anddev.andengine.util.path.NegativeStepCostException;
 import org.anddev.andengine.util.path.Path;
 
 /**
@@ -66,7 +67,7 @@ public class AStarPathFinder<T> implements IPathFinder<T> {
 	// ===========================================================
 
 	@Override
-	public Path findPath(final T pEntity, final float pMaxCost, final int pFromTileColumn, final int pFromTileRow, final int pToTileColumn, final int pToTileRow) {
+	public Path findPath(final T pEntity, final float pMaxCost, final int pFromTileColumn, final int pFromTileRow, final int pToTileColumn, final int pToTileRow) throws NegativeStepCostException {
 		final ITiledMap<T> tiledMap = this.mTiledMap;
 		if(tiledMap.isTileBlocked(pEntity, pToTileColumn, pToTileRow)) {
 			return null;
@@ -124,8 +125,7 @@ public class AStarPathFinder<T> implements IPathFinder<T> {
 						final float stepCost = tiledMap.getStepCost(pEntity, current.mTileColumn, current.mTileRow, neighborTileColumn, neighborTileRow);
 						
 						if(stepCost < 0) {
-							/* can not handle negative step cost! */
-							return null;
+							throw new NegativeStepCostException();
 						}
 						
 						final float neighborCost = current.mCost + stepCost;

--- a/src/org/anddev/andengine/util/path/astar/AStarPathFinder.java
+++ b/src/org/anddev/andengine/util/path/astar/AStarPathFinder.java
@@ -134,12 +134,8 @@ public class AStarPathFinder<T> implements IPathFinder<T> {
 
 						/* Re-evaluate if there is a better path. */
 						if(neighborCost < neighbor.mCost) {
-							// TODO Is this ever possible with AStar ??
 							if(openNodes.contains(neighbor)) {
 								openNodes.remove(neighbor);
-							}
-							if(visitedNodes.contains(neighbor)) {
-								visitedNodes.remove(neighbor);
 							}
 						}
 

--- a/src/org/anddev/andengine/util/path/astar/AStarPathFinder.java
+++ b/src/org/anddev/andengine/util/path/astar/AStarPathFinder.java
@@ -121,7 +121,14 @@ public class AStarPathFinder<T> implements IPathFinder<T> {
 					final int neighborTileRow = dY + current.mTileRow;
 
 					if(!this.isTileBlocked(pEntity, pFromTileColumn, pFromTileRow, neighborTileColumn, neighborTileRow)) {
-						final float neighborCost = current.mCost + tiledMap.getStepCost(pEntity, current.mTileColumn, current.mTileRow, neighborTileColumn, neighborTileRow);
+						final float stepCost = tiledMap.getStepCost(pEntity, current.mTileColumn, current.mTileRow, neighborTileColumn, neighborTileRow);
+						
+						if(stepCost < 0) {
+							/* can not handle negative step cost! */
+							return null;
+						}
+						
+						final float neighborCost = current.mCost + stepCost;
 						final Node neighbor = nodes[neighborTileRow][neighborTileColumn];
 						tiledMap.onTileVisitedByPathFinder(neighborTileColumn, neighborTileRow);
 

--- a/src/org/anddev/andengine/util/path/astar/AStarPathFinder.java
+++ b/src/org/anddev/andengine/util/path/astar/AStarPathFinder.java
@@ -239,7 +239,18 @@ public class AStarPathFinder<T> implements IPathFinder<T> {
 			} else if (totalCost > totalCostOther) {
 				return 1;
 			} else {
-				return 0;
+				// costs are equal, use coordinates for comparison
+				if(mTileColumn != pOther.mTileColumn)
+				{
+					return (mTileColumn < pOther.mTileColumn)?-1:1;
+				}
+				else if(mTileRow == pOther.mTileRow)
+				{
+					return 0;
+				}
+				else {
+					return (mTileRow < pOther.mTileRow)?-1:1;
+				}
 			}
 		}
 


### PR DESCRIPTION
Here are some improvements to AStarPathFinder:

* A* algorithm can not handle negative step cost, so abort in that case
* Since negative step cost are forbidden, the cost for visited nodes can not be improved
* Instead of constantly sorting the openNodes (takes O(n²log n) time in total) just take the minimum cost node (only O(n²) time in total)
* The step cost are float, so the max. cost should be float as well