### PR TITLE
Added (get|set)Tag methods to IModifier

### DIFF
--- a/src/org/andengine/util/modifier/BaseModifier.java
+++ b/src/org/andengine/util/modifier/BaseModifier.java
@@ -23,6 +23,7 @@ public abstract class BaseModifier<T> implements IModifier<T> {
 	protected boolean mFinished;
 	private boolean mAutoUnregisterWhenFinished = true;
 	private final SmartList<IModifierListener<T>> mModifierListeners = new SmartList<IModifierListener<T>>(2);
+	private int mTag;
 
 	// ===========================================================
 	// Constructors
@@ -39,7 +40,15 @@ public abstract class BaseModifier<T> implements IModifier<T> {
 	// ===========================================================
 	// Getter & Setter
 	// ===========================================================
+	@Override
+	public int getTag() {
+		return this.mTag;
+	}
 
+	@Override
+	public void setTag(final int pTag) {
+		this.mTag = pTag;
+	}
 	// ===========================================================
 	// Methods for/from SuperClass/Interfaces
 	// ===========================================================

--- a/src/org/andengine/util/modifier/IModifier.java
+++ b/src/org/andengine/util/modifier/IModifier.java
@@ -47,6 +47,8 @@ public interface IModifier<T> {
 
 	public float getSecondsElapsed();
 	public float getDuration();
+	public void setTag(final int pTag);
+	public int getTag();
 
 	public float onUpdate(final float pSecondsElapsed, final T pItem);
 


### PR DESCRIPTION
This might be used e.g. to remove entity modifiers via
unregisterEntityModifiers(IEntityModifierMatcher)

It might also make sense to add some methods to Entity allowing easy (get|unregister)ModifierByTag, but that's a story for another commit.
