### PR TITLE
setAssetBasePath for TMXLoader and TSXLoader

### DIFF
--- a/src/org/anddev/andengine/entity/layer/tiled/tmx/TMXLoader.java
+++ b/src/org/anddev/andengine/entity/layer/tiled/tmx/TMXLoader.java
@@ -38,6 +38,8 @@ public class TMXLoader {
 	private final TextureOptions mTextureOptions;
 	private final ITMXTilePropertiesListener mTMXTilePropertyListener;
 
+	private static String sAssetBasePath = "";
+
 	// ===========================================================
 	// Constructors
 	// ===========================================================
@@ -65,6 +67,17 @@ public class TMXLoader {
 	// Getter & Setter
 	// ===========================================================
 
+	/**
+	 * @param pAssetBasePath must end with '<code>/</code>' or have <code>.length() == 0</code>.
+	 */
+	public static void setAssetBasePath(final String pAssetBasePath) {
+		if(pAssetBasePath.endsWith("/") || pAssetBasePath.length() == 0) {
+			TMXLoader.sAssetBasePath = pAssetBasePath;
+		} else {
+			throw new IllegalArgumentException("pAssetBasePath must end with '/' or be lenght zero.");
+		}
+	}
+
 	// ===========================================================
 	// Methods for/from SuperClass/Interfaces
 	// ===========================================================
@@ -75,9 +88,9 @@ public class TMXLoader {
 
 	public TMXTiledMap loadFromAsset(final Context pContext, final String pAssetPath) throws TMXLoadException {
 		try {
-			return this.load(pContext.getAssets().open(pAssetPath));
+			return this.load(pContext.getAssets().open(TMXLoader.sAssetBasePath + pAssetPath));
 		} catch (final IOException e) {
-			throw new TMXLoadException("Could not load TMXTiledMap from asset: " + pAssetPath, e);
+			throw new TMXLoadException("Could not load TMXTiledMap from asset: " + TMXLoader.sAssetBasePath + pAssetPath, e);
 		}
 	}
 

--- a/src/org/anddev/andengine/entity/layer/tiled/tmx/TSXLoader.java
+++ b/src/org/anddev/andengine/entity/layer/tiled/tmx/TSXLoader.java
@@ -37,6 +37,8 @@ public class TSXLoader {
 	private final TextureManager mTextureManager;
 	private final TextureOptions mTextureOptions;
 
+	private static String sAssetBasePath = "";
+
 	// ===========================================================
 	// Constructors
 	// ===========================================================
@@ -51,6 +53,17 @@ public class TSXLoader {
 	// Getter & Setter
 	// ===========================================================
 
+	/**
+	 * @param pAssetBasePath must end with '<code>/</code>' or have <code>.length() == 0</code>.
+	 */
+	public static void setAssetBasePath(final String pAssetBasePath) {
+		if(pAssetBasePath.endsWith("/") || pAssetBasePath.length() == 0) {
+			TSXLoader.sAssetBasePath = pAssetBasePath;
+		} else {
+			throw new IllegalArgumentException("pAssetBasePath must end with '/' or be lenght zero.");
+		}
+	}
+
 	// ===========================================================
 	// Methods for/from SuperClass/Interfaces
 	// ===========================================================
@@ -61,9 +74,9 @@ public class TSXLoader {
 
 	public TMXTileSet loadFromAsset(final Context pContext, final int pFirstGlobalTileID, final String pAssetPath) throws TSXLoadException {
 		try {
-			return this.load(pFirstGlobalTileID, pContext.getAssets().open(pAssetPath));
+			return this.load(pFirstGlobalTileID, pContext.getAssets().open(TSXLoader.sAssetBasePath + pAssetPath));
 		} catch (final IOException e) {
-			throw new TSXLoadException("Could not load TMXTileSet from asset: " + pAssetPath, e);
+			throw new TSXLoadException("Could not load TMXTileSet from asset: " + TSXLoader.sAssetBasePath + pAssetPath, e);
 		}
 	}
 


### PR DESCRIPTION
This stuff here has been bugging me for quite a while. Would be great if you could merge it. Without an asset base path, all TSX files have to have absolute paths - which sometimes is a bit annoying. (I am loading a level map from a subdirectory and want to simply have the TMX and the TSX in the same directory for every level without having to specify the level path in the TSX file)