### PR TITLE
Added detection for edit mode in RenderSurfaceView

### DIFF
--- a/src/org/andengine/opengl/view/RenderSurfaceView.java
+++ b/src/org/andengine/opengl/view/RenderSurfaceView.java
@@ -61,6 +61,10 @@ public class RenderSurfaceView extends GLSurfaceView {
 	 */
 	@Override
 	protected void onMeasure(final int pWidthMeasureSpec, final int pHeightMeasureSpec) {
+		if(this.isInEditMode()) {
+			super.onMeasure(pWidthMeasureSpec, pHeightMeasureSpec);
+			return;
+		}
 		this.mEngineRenderer.mEngine.getEngineOptions().getResolutionPolicy().onMeasure(this, pWidthMeasureSpec, pHeightMeasureSpec);
 	}
 


### PR DESCRIPTION
When using the LayoutBaseActivity, the RenderSurfaceView did not properly detect whether it was in edit mode or not. This led to a NullPointerException when adding a RenderSurfaceView directly to an XML layout. This commit fixes that issue and uses the default GLSurfaceView onMeasure() method.
