### PR TITLE
Reduce number of glEnable and glDisable calls

### DIFF
--- a/src/org/andengine/entity/shape/Shape.java
+++ b/src/org/andengine/entity/shape/Shape.java
@@ -115,14 +115,14 @@ public abstract class Shape extends Entity implements IShape {
 		if(this.mBlendingEnabled) {
 			pGLState.enableBlend();
 			pGLState.blendFunction(this.mBlendFunctionSource, this.mBlendFunctionDestination);
+		} else {
+			pGLState.disableBlend();
 		}
 	}
 
 	@Override
 	protected void postDraw(final GLState pGLState, final Camera pCamera) {
-		if(this.mBlendingEnabled) {
-			pGLState.disableBlend();
-		}
+
 	}
 
 	@Override


### PR DESCRIPTION
There is no need for postDraw to disable blending on every postDraw().
It is enough if Shape will make sure that it has the correct blending
setting in preDraw() method.

Since 99% of Shapes are drawn with blending enabled, this will
substantially reduce number of unnecessary JNI calls, and (hopefully)
improve overall performance.

I do not have a _reliable_ way to test it, but I _think_ I can notice few FPS difference after applying this patch.
