### PR TITLE
Reduce number of glEnable and glDisable calls

### DIFF
--- a/src/org/andengine/entity/shape/Shape.java
+++ b/src/org/andengine/entity/shape/Shape.java
@@ -115,14 +115,13 @@ public abstract class Shape extends Entity implements IShape {
 		if(this.mBlendingEnabled) {
 			pGLState.enableBlend();
 			pGLState.blendFunction(this.mBlendFunctionSource, this.mBlendFunctionDestination);
+		} else {
+			pGLState.disableBlend();
 		}
 	}
 
 	@Override
 	protected void postDraw(final GLState pGLState, final Camera pCamera) {
-		if(this.mBlendingEnabled) {
-			pGLState.disableBlend();
-		}
 	}
 
 	@Override


### PR DESCRIPTION
There is no reason for postDraw() to disable blending on every call.
It will be enough if Shape makes sure that it has the correct blending
setting in preDraw() method.

Since 99% of Shapes are drawn with blending enabled, applying this
patch substantially reduces number of redundant JNI calls, and (hopefully)
improves overall performance.

(previous version of this pull request was accidentally removed with my latest copy-paste failure...)
