### PR TITLE
Fixed calculateNodeID Method bug.

### DIFF
--- a/src/org/andengine/util/algorithm/path/astar/AStarPathFinder.java
+++ b/src/org/andengine/util/algorithm/path/astar/AStarPathFinder.java
@@ -1,5 +1,8 @@
 package org.andengine.util.algorithm.path.astar;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
 import org.andengine.util.adt.list.ShiftList;
 import org.andengine.util.adt.map.LongSparseArray;
 import org.andengine.util.adt.queue.IQueue;
@@ -185,7 +188,7 @@ public class AStarPathFinder<T> implements IPathFinder<T> {
 	// Inner and Anonymous Classes
 	// ===========================================================
 
-	private static final class Node implements Comparable<Node> {
+	public static final class Node implements Comparable<Node> {
 		// ===========================================================
 		// Constants
 		// ===========================================================
@@ -264,7 +267,9 @@ public class AStarPathFinder<T> implements IPathFinder<T> {
 		// ===========================================================
 
 		public static long calculateID(final int pX, final int pY) {
-			return (((long)pX) << 32) | pY;
+			final ByteBuffer byteBuffer = ByteBuffer.allocateDirect(16);
+			byteBuffer.order(ByteOrder.BIG_ENDIAN);
+			return byteBuffer.putInt(pX).putInt(pY).getLong(0);
 		}
 
 		public boolean equals(final Node pNode) {


### PR DESCRIPTION
always failure org.andengine.util.algorithm.path.astar.AStarPathFinderTest.testCalculateNodeID on Android 4.1.2 on GalaxyNexus

``` java
junit.framework.AssertionFailedError: Expected:
1000000000000000000000000000000010000000000000000000000000000000 Actual:
1111111111111111111111111111111110000000000000000000000000000000
at org.andengine.util.algorithm.path.astar.AStarPathFinderTest.testCalculateNodeID(AStarPathFinderTest.java:113)
at org.andengine.util.algorithm.path.astar.AStarPathFinderTest.testCalculateNodeID(AStarPathFinderTest.java:43)
at java.lang.reflect.Method.invokeNative(Native Method)
at android.test.AndroidTestRunner.runTest(AndroidTestRunner.java:190)
at android.test.AndroidTestRunner.runTest(AndroidTestRunner.java:175)
at android.test.InstrumentationTestRunner.onStart(InstrumentationTestRunner.java:555)
at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:1584)
```
