### PR TITLE
Modified RunnableHandler to process runnables FIFO

### DIFF
--- a/src/org/andengine/engine/handler/runnable/RunnableHandler.java
+++ b/src/org/andengine/engine/handler/runnable/RunnableHandler.java
@@ -38,9 +38,10 @@ public class RunnableHandler implements IUpdateHandler {
 	public synchronized void onUpdate(final float pSecondsElapsed) {
 		final ArrayList<Runnable> runnables = this.mRunnables;
 		final int runnableCount = runnables.size();
-		for(int i = runnableCount - 1; i >= 0; i--) {
-			runnables.remove(i).run();
+		for(int i=0; i<runnableCount; i++){
+			runnables.get(i).run();
 		}
+		runnables.clear();
 	}
 
 	@Override


### PR DESCRIPTION
Contrary to the expectations of every Handler, I found that the RunnableHandler processes runnables in a LIFO (stack-like fashion).  

The correct approach is to process them in order and then clear the list, as I've done here.  This not only processes the items in FIFO order as expected, it also avoids any overhead of trying to remove the first element of the ArrayList.
