### PR TITLE
Engine is now aware of being reloaded

### DIFF
--- a/src/org/andengine/opengl/font/FontManager.java
+++ b/src/org/andengine/opengl/font/FontManager.java
@@ -25,6 +25,7 @@ public class FontManager {
 	private final ArrayList<Font> mFontsManaged = new ArrayList<Font>();
 	private final ArrayList<BitmapFont> mBitmapFontsManaged = new ArrayList<BitmapFont>();
 	private final HashMap<String, IFont> mFontsMapped = new HashMap<String, IFont>();
+	private boolean mReloading;
 
 	// ===========================================================
 	// Constructors
@@ -141,7 +142,7 @@ public class FontManager {
 		}
 	}
 
-	public synchronized void updateFonts(final GLState pGLState) {
+	public synchronized boolean updateFonts(final GLState pGLState) {
 		final ArrayList<Font> fonts = this.mFontsManaged;
 		final int fontCount = fonts.size();
 		if(fontCount > 0){
@@ -149,9 +150,17 @@ public class FontManager {
 				fonts.get(i).update(pGLState);
 			}
 		}
+
+		if (this.mReloading) {
+			this.mReloading = false;
+			return true;
+		} else {
+			return false;
+		}
 	}
 
 	public synchronized void onReload() {
+		this.mReloading = true;
 		final ArrayList<Font> managedFonts = this.mFontsManaged;
 		for(int i = managedFonts.size() - 1; i >= 0; i--) {
 			managedFonts.get(i).invalidateLetters();

--- a/src/org/andengine/opengl/texture/TextureManager.java
+++ b/src/org/andengine/opengl/texture/TextureManager.java
@@ -39,6 +39,7 @@ public class TextureManager {
 	private final ArrayList<ITexture> mTexturesToBeUnloaded = new ArrayList<ITexture>();
 
 	private TextureWarmUpVertexBufferObject mTextureWarmUpVertexBufferObject;
+	private boolean mReloading;
 
 	// ===========================================================
 	// Constructors
@@ -61,6 +62,7 @@ public class TextureManager {
 	}
 
 	public synchronized void onReload() {
+		this.mReloading = true;
 		final HashSet<ITexture> managedTextures = this.mTexturesManaged;
 		if(!managedTextures.isEmpty()) {
 			for(final ITexture texture : managedTextures) { // TODO Can the use of the iterator be avoided somehow?
@@ -225,7 +227,7 @@ public class TextureManager {
 		}
 	}
 
-	public synchronized void updateTextures(final GLState pGLState) {
+	public synchronized boolean updateTextures(final GLState pGLState) {
 		final HashSet<ITexture> texturesManaged = this.mTexturesManaged;
 		final ArrayList<ITexture> texturesLoaded = this.mTexturesLoaded;
 		final ArrayList<ITexture> texturesToBeLoaded = this.mTexturesToBeLoaded;
@@ -280,6 +282,13 @@ public class TextureManager {
 		/* Finally invoke the GC if anything has changed. */
 		if((texturesToBeLoadedCount > 0) || (texturesToBeUnloadedCount > 0)) {
 			System.gc();
+		}
+
+		if (this.mReloading) {
+			this.mReloading = false;
+			return true;
+		} else {
+			return false;
 		}
 	}
 

--- a/src/org/andengine/opengl/vbo/VertexBufferObjectManager.java
+++ b/src/org/andengine/opengl/vbo/VertexBufferObjectManager.java
@@ -24,6 +24,8 @@ public class VertexBufferObjectManager {
 
 	private final ArrayList<IVertexBufferObject> mVertexBufferObjectsToBeUnloaded = new ArrayList<IVertexBufferObject>();
 
+	private boolean mReloading;
+
 	// ===========================================================
 	// Constructors
 	// ===========================================================
@@ -91,6 +93,7 @@ public class VertexBufferObjectManager {
 	}
 
 	public synchronized void onReload() {
+		this.mReloading = true;
 		final ArrayList<IVertexBufferObject> vertexBufferObjectsLoaded = this.mVertexBufferObjectsLoaded;
 		for(int i = vertexBufferObjectsLoaded.size() - 1; i >= 0; i--) {
 			vertexBufferObjectsLoaded.get(i).setNotLoadedToHardware();
@@ -99,7 +102,7 @@ public class VertexBufferObjectManager {
 		vertexBufferObjectsLoaded.clear();
 	}
 
-	public synchronized void updateVertexBufferObjects(final GLState pGLState) {
+	public synchronized boolean updateVertexBufferObjects(final GLState pGLState) {
 		final ArrayList<IVertexBufferObject> vertexBufferObjectsLoaded = this.mVertexBufferObjectsLoaded;
 		final ArrayList<IVertexBufferObject> vertexBufferObjectsToBeUnloaded = this.mVertexBufferObjectsToBeUnloaded;
 
@@ -110,6 +113,13 @@ public class VertexBufferObjectManager {
 				vertexBufferObjectToBeUnloaded.unloadFromHardware(pGLState);
 			}
 			vertexBufferObjectsLoaded.remove(vertexBufferObjectToBeUnloaded);
+		}
+
+		if (this.mReloading) {
+			this.mReloading = false;
+			return true;
+		} else {
+			return false;
 		}
 	}
 


### PR DESCRIPTION
When game was resumed, Engine::onUpdate(pNanosecondsElapsed)
was called with unusually big value of pNanosecondsElapsed.
This caused Box2D simulation instability or undesired behavior of particle systems.

This patch fixes this issue by adding lag awarness to the Engine.
Vertex, Texture and Font managers will return true from theirs update\* method
if feeling guilty of unusually long execution time (due to reloading).
