### PR TITLE
Move ExpireParticleIntiializer to initializer package.

### DIFF
--- a/src/org/andengine/entity/particle/initializer/ExpireParticleInitializer.java
+++ b/src/org/andengine/entity/particle/initializer/ExpireParticleInitializer.java
@@ -1,8 +1,7 @@
-package org.andengine.entity.particle.modifier;
+package org.andengine.entity.particle.initializer;
 
 import org.andengine.entity.IEntity;
 import org.andengine.entity.particle.Particle;
-import org.andengine.entity.particle.initializer.IParticleInitializer;
 import org.andengine.util.math.MathUtils;
 
 /**


### PR DESCRIPTION
It seems that the ExpireParticleInitializer is placed at the wrong package. (It is placed under particle modifier package now)

And, in AndEngineExamples project, the three paritcle examples need to do re-organize imports, if you need another pull request for that, please let me know.
