### PR TITLE
GLES2 - TexturePacker with rotated TiledSprite bug correction

### DIFF
--- a/src/org/andengine/opengl/texture/region/TiledTextureRegion.java
+++ b/src/org/andengine/opengl/texture/region/TiledTextureRegion.java
@@ -64,9 +64,17 @@ public class TiledTextureRegion extends BaseTextureRegion implements ITiledTextu
 		for(int tileColumn = 0; tileColumn < pTileColumns; tileColumn++) {
 			for(int tileRow = 0; tileRow < pTileRows; tileRow++) {
 				final int tileIndex = tileRow * pTileColumns + tileColumn;
-
-				final int x = pTextureX + tileColumn * tileWidth;
-				final int y = pTextureY + tileRow * tileHeight;
+				
+				final int x;
+				final int y;
+				if (pRotated) {
+					x = pTextureX + pTextureHeight - (tileRow + 1) * tileHeight;
+					y = pTextureY + tileColumn * tileWidth;
+					
+				} else {
+					x = pTextureX + tileColumn * tileWidth;
+					y = pTextureY + tileRow * tileHeight;
+				}
 				textureRegions[tileIndex] = new TextureRegion(pTexture, x, y, tileWidth, tileHeight, pRotated);
 			}
 		}


### PR DESCRIPTION
I am using Texture packs with rotated TiledSprites (last up-to-date version of AndEngine-GLES2) and noticed that the TiledTextureRegion.create method is bugged in case the tiled texture is rotated.

Here is my way to create the TiledTexture:

``` java
final TexturePack lTexturePack = new TexturePackLoader(getAssets(), getEngine().getTextureManager()).loadFromAsset(TEXTURE_PACK_PATH_TO_XML_FILE, TEXTURE_PACKED_FOLDER);
lTexturePack.loadTexture();

final TexturePackTextureRegion lTexturePackerTextureRegion = lTexturePack.getTexturePackTextureRegionLibrary().get(IMAGE_ID_IN_PACK);
final TiledTextureRegion.create(lTexturePack.getTexture(), (int) lTexturePackerTextureRegion.getTextureX(), (int) lTexturePackerTextureRegion.getTextureY(),
                                (int) lTexturePackerTextureRegion.getWidth(), (int) lTexturePackerTextureRegion.getHeight(),
                                NB_COLS, NB_ROWS, lTexturePackerTextureRegion.isRotated());
```

You can find a proposal for correction in the pull request (TiledTextureRegion.create method).

Regards,
~ Florian Minjat
