### PR TITLE
Modifiers improved to be able to use them in more general pools :

### DIFF
--- a/src/org/andengine/util/modifier/BaseDoubleValueSpanModifier.java
+++ b/src/org/andengine/util/modifier/BaseDoubleValueSpanModifier.java
@@ -111,9 +111,13 @@ public abstract class BaseDoubleValueSpanModifier<T> extends BaseSingleValueSpan
 	// ===========================================================
 	// Methods
 	// ===========================================================
-	
+
 	public void reset(final float pDuration, final float pFromValueA, final float pToValueA, final float pFromValueB, final float pToValueB) {
-		super.reset(pDuration, pFromValueA, pToValueA);
+		reset(pDuration, pFromValueA, pToValueA, pFromValueB, pToValueB, mEaseFunction);
+	}
+	
+	public void reset(final float pDuration, final float pFromValueA, final float pToValueA, final float pFromValueB, final float pToValueB, final IEaseFunction pEaseFunction) {
+		super.reset(pDuration, pFromValueA, pToValueA, pEaseFunction);
 
 		this.mFromValueB = pFromValueB;
 		this.mValueSpanB = pToValueB - pFromValueB;

--- a/src/org/andengine/util/modifier/BaseModifier.java
+++ b/src/org/andengine/util/modifier/BaseModifier.java
@@ -67,12 +67,21 @@ public abstract class BaseModifier<T> implements IModifier<T> {
 	}
 
 	@Override
+	public void clearModifierListeners() {
+		this.mModifierListeners.clear();
+	}
+
+	@Override
 	public boolean removeModifierListener(final IModifierListener<T> pModifierListener) {
 		if(pModifierListener == null) {
 			return false;
 		} else {
 			return this.mModifierListeners.remove(pModifierListener);
 		}
+	}
+	
+	@Override
+	public void onUnregister(final T pItem) {
 	}
 
 	@Override

--- a/src/org/andengine/util/modifier/BaseSingleValueSpanModifier.java
+++ b/src/org/andengine/util/modifier/BaseSingleValueSpanModifier.java
@@ -22,7 +22,7 @@ public abstract class BaseSingleValueSpanModifier<T> extends BaseDurationModifie
 	private float mFromValue;
 	private float mValueSpan;
 
-	protected final IEaseFunction mEaseFunction;
+	protected IEaseFunction mEaseFunction;
 
 	// ===========================================================
 	// Constructors
@@ -67,6 +67,11 @@ public abstract class BaseSingleValueSpanModifier<T> extends BaseDurationModifie
 	public float getToValue() {
 		return this.mFromValue + this.mValueSpan;
 	}
+	
+	public IEaseFunction getEaseFunction() {
+		return mEaseFunction;
+	}
+	
 
 	// ===========================================================
 	// Methods for/from SuperClass/Interfaces
@@ -90,13 +95,18 @@ public abstract class BaseSingleValueSpanModifier<T> extends BaseDurationModifie
 	// ===========================================================
 	// Methods
 	// ===========================================================
-	
+
 	public void reset(final float pDuration, final float pFromValue, final float pToValue) {
+		reset(pDuration, pFromValue, pToValue, mEaseFunction);
+	}
+	
+	public void reset(final float pDuration, final float pFromValue, final float pToValue, final IEaseFunction pEaseFunction) {
 		super.reset();
 		
 		this.mDuration = pDuration;
 		this.mFromValue = pFromValue;
 		this.mValueSpan = pToValue - pFromValue;
+		this.mEaseFunction = pEaseFunction;
 	}
 
 	// ===========================================================

--- a/src/org/andengine/util/modifier/IModifier.java
+++ b/src/org/andengine/util/modifier/IModifier.java
@@ -49,9 +49,12 @@ public interface IModifier<T> {
 	public float getDuration();
 
 	public float onUpdate(final float pSecondsElapsed, final T pItem);
+	
+	public void onUnregister(final T pItem);
 
 	public void addModifierListener(final IModifierListener<T> pModifierListener);
 	public boolean removeModifierListener(final IModifierListener<T> pModifierListener);
+	public void clearModifierListeners();
 
 	// ===========================================================
 	// Inner and Anonymous Classes

--- a/src/org/andengine/util/modifier/ModifierList.java
+++ b/src/org/andengine/util/modifier/ModifierList.java
@@ -56,6 +56,26 @@ public class ModifierList<T> extends SmartList<IModifier<T>> implements IUpdateH
 			return super.add(pModifier);
 		}
 	}
+	
+    @Override
+    public void clear() {
+    	final int modifierCount = this.size();
+		if(modifierCount > 0) {
+			for(int i = modifierCount - 1; i >= 0; i--) {
+				final IModifier<T> modifier = this.get(i);
+				modifier.onUnregister(this.mTarget);
+			}
+		}
+		super.clear();
+    }
+	
+	@Override
+	public boolean remove(final Object pObject) {
+		@SuppressWarnings("unchecked")
+		final IModifier<T> modifier = (IModifier<T>) pObject;
+		modifier.onUnregister(this.mTarget);
+		return super.remove(pObject);
+	}
 
 	@Override
 	public void onUpdate(final float pSecondsElapsed) {
@@ -66,6 +86,7 @@ public class ModifierList<T> extends SmartList<IModifier<T>> implements IUpdateH
 				modifier.onUpdate(pSecondsElapsed, this.mTarget);
 				if(modifier.isFinished() && modifier.isAutoUnregisterWhenFinished()) {
 					this.remove(i);
+					modifier.onUnregister(this.mTarget);
 				}
 			}
 		}


### PR DESCRIPTION
This patch improves the modifiers to be able to use them in pools:
- reset methods taking a IEaseFunction as parameter added in BaseDoubleValueSpanModifier and BaseSingleValueSpanModifier classes
- IModifier.clearModifierListeners method added to able to clear all modifier listeners when the modifier goes back in the pool
- IModifier.onUnregister event method added to be able to recycle the modifier back to the pool easily
- ModifierList.clear, remove and onUpdate method overridden from super class to call onUnregister event on modifiers

With this patch it's possible to create and use a pool of modifiers like this:

``` java
new GenericPool<MoveModifier> mMoveModifierPool = new GenericPool<MoveModifier>() {
    @Override
    protected MoveModifier onAllocatePoolItem() {
        final MoveModifier lRes = new MoveModifier(0, 0, 0, 0, 0) {
            @Override
            public void onUnregister(final IEntity pItem) {
                recyclePoolItem(this);
            }
        };
        lRes.setAutoUnregisterWhenFinished(true);
        return lRes;
    }

    @Override
    protected void onHandleObtainItem(final MoveModifier pItem) {
        pItem.clearModifierListeners();
    }
};

final MoveModifier lMoveModifier = mMoveModifierPool.obtainPoolItem();
lMoveModifier.reset(aDuration, fromX, toX, fromY, toY, EaseStrongIn.getInstance());
lMoveModifier.addModifierListener(new IModifierListener<IEntity>() {
    @Override public void onModifierStarted(final IModifier<IEntity> pModifier, final IEntity pItem) { }

    @Override
    public void onModifierFinished(final IModifier<IEntity> pModifier, final IEntity pItem) {
        // do something
    }
});
aShape.registerEntityModifier(lMoveModifier);
```
