### PR TITLE
Sprite.markTextureRegionChanged() method added

### DIFF
--- a/src/org/andengine/entity/sprite/Sprite.java
+++ b/src/org/andengine/entity/sprite/Sprite.java
@@ -204,13 +204,17 @@ public class Sprite extends RectangularShape {
 		this.mSpriteVertexBufferObject.onUpdateColor(this);
 	}
 
-	protected void onUpdateTextureCoordinates() {
-		this.mSpriteVertexBufferObject.onUpdateTextureCoordinates(this);
-	}
-
 	// ===========================================================
 	// Methods
 	// ===========================================================
+
+	protected void onUpdateTextureCoordinates() {
+		this.mSpriteVertexBufferObject.onUpdateTextureCoordinates(this);
+	}
+	
+	public void markTextureRegionChanged() {
+		onUpdateTextureCoordinates();
+	}
 
 	// ===========================================================
 	// Inner and Anonymous Classes


### PR DESCRIPTION
This method can be used after modifications to a Sprite texture to update the Sprite with a call to onUpdateTextureCoordinates().

E.g. with this method to truncate the Sprite texture:

``` java
public static void truncateSpriteTextureRegion(final Sprite pSprite, final ITextureRegion pOriginalTextureRegion, final float pLeftX, final float pRightX, final float pTopY, final float pBottomY, final VertexBufferObjectManager pVertexBufferObjectManager) {
    final float lTruncX, lTruncY, lTruncWidth, lTruncHeight;
    if (pOriginalTextureRegion.isRotated()) {
        lTruncHeight = pOriginalTextureRegion.getWidth() - pLeftX - pRightX;
        lTruncWidth = pOriginalTextureRegion.getHeight() - pTopY - pBottomY;
        lTruncX = pOriginalTextureRegion.getTextureX() + pBottomY;
        lTruncY = pOriginalTextureRegion.getTextureY() + pLeftX;
    } else {
        lTruncHeight = pOriginalTextureRegion.getHeight() - pTopY - pBottomY;
        lTruncWidth = pOriginalTextureRegion.getWidth() - pLeftX - pRightX;
        lTruncX = pOriginalTextureRegion.getTextureX() + pLeftX;
        lTruncY = pOriginalTextureRegion.getTextureY() + pTopY;
    }
    pSprite.getTextureRegion().set(lTruncX, lTruncY, lTruncWidth, lTruncHeight);
    pSprite.markTextureRegionChanged();
    if (pOriginalTextureRegion.isRotated()) {
        pSprite.setWidth(lTruncHeight);
        pSprite.setHeight(lTruncWidth);
    } else {
        pSprite.setWidth(lTruncWidth);
        pSprite.setHeight(lTruncHeight);
    }
}
```
