### PR TITLE
More explicit onManaged* Exceptions

### DIFF
--- a/src/org/andengine/entity/Entity.java
+++ b/src/org/andengine/entity/Entity.java
@@ -1223,14 +1223,19 @@ public class Entity implements IEntity {
 
 	@Override
 	public void toString(final StringBuilder pStringBuilder) {
-		pStringBuilder.append(this.getClass().getSimpleName());
+		pStringBuilder.append(this.getClass().getName());
 
 		if((this.mChildren != null) && (this.mChildren.size() > 0)) {
 			pStringBuilder.append(" [");
 			final SmartList<IEntity> entities = this.mChildren;
 			for(int i = 0; i < entities.size(); i++) {
-				entities.get(i).toString(pStringBuilder);
-				if(i < (entities.size() - 1)) {
+				final IEntity lEntity = entities.get(i);
+				if (lEntity == null) {
+					pStringBuilder.append("null");
+				} else {
+					lEntity.toString(pStringBuilder);
+				}
+				if(i < entities.size() - 1) {
 					pStringBuilder.append(", ");
 				}
 			}
@@ -1363,11 +1368,15 @@ public class Entity implements IEntity {
 
 				{ /* Draw children behind this Entity. */
 					for(; i < childCount; i++) {
-						final IEntity child = children.get(i);
-						if(child.getZIndex() < 0) {
-							child.onDraw(pGLState, pCamera);
-						} else {
-							break;
+						try {
+							final IEntity child = children.get(i);
+							if(child.getZIndex() < 0) {
+								child.onDraw(pGLState, pCamera);
+							} else {
+								break;
+							}
+						} catch (RuntimeException e) {
+							throw new RuntimeException("onManagedDraw(...) entity='" + this.getClass().getName() + "' KO during onDraw of child " + i + " (" + toString() + ")", e);
 						}
 					}
 				}
@@ -1379,7 +1388,11 @@ public class Entity implements IEntity {
 
 				{ /* Draw children in front of this Entity. */
 					for(; i < childCount; i++) {
-						children.get(i).onDraw(pGLState, pCamera);
+						try {
+							children.get(i).onDraw(pGLState, pCamera);
+						} catch (RuntimeException e) {
+							throw new RuntimeException("onManagedDraw(...) entity='" + this.getClass().getName() + "' KO during onDraw of child " + i + " (" + toString() + ")", e);
+						}
 					}
 				}
 			}
@@ -1399,7 +1412,11 @@ public class Entity implements IEntity {
 			final SmartList<IEntity> entities = this.mChildren;
 			final int entityCount = entities.size();
 			for(int i = 0; i < entityCount; i++) {
-				entities.get(i).onUpdate(pSecondsElapsed);
+				try {
+					entities.get(i).onUpdate(pSecondsElapsed);
+				} catch (RuntimeException e) {
+					throw new RuntimeException("onManagedUpdate(...) entity='" + this.getClass().getName() + "' KO during onUpdate of child " + i + " (" + toString() + ")", e);
+				}
 			}
 		}
 	}

--- a/src/org/andengine/entity/sprite/batch/SpriteGroup.java
+++ b/src/org/andengine/entity/sprite/batch/SpriteGroup.java
@@ -157,7 +157,11 @@ public class SpriteGroup extends DynamicSpriteBatch {
 		} else {
 			final int childCount = children.size();
 			for(int i = 0; i < childCount; i++) {
-				this.drawWithoutChecks((Sprite)children.get(i));
+				try {
+					this.drawWithoutChecks((Sprite)children.get(i));
+				} catch (RuntimeException e) {
+					throw new RuntimeException("onUpdateSpriteBatch(...) entity='" + this.getClass().getName() + "' KO during onDraw of child " + i + " (" + toString() + ")", e);
+				}
 			}
 			return true;
 		}

--- a/src/org/andengine/ui/activity/BaseGameActivity.java
+++ b/src/org/andengine/ui/activity/BaseGameActivity.java
@@ -370,7 +370,9 @@ public abstract class BaseGameActivity extends BaseActivity implements IGameInte
 		BaseGameActivity.this.runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
-				BaseGameActivity.this.onResumeGame();
+				if (isGameLoaded()) {
+					BaseGameActivity.this.onResumeGame();
+				}
 			}
 		});
 	}


### PR DESCRIPTION
Exceptions can occurred in the onManagedDraw or onManagedUpdate methods of Entity and onUpdateSpriteBatch method of SpriteBatch:
- IndexOutOfBound if a detach was done on the UI Thread;
- NPE if an attach is done with a null value...

These exceptions can be pretty tough to track and correct. 

This patch display more informations about the exact entity which can problem by adding try/catch blocks to these methods and wrapping the exception with context information.

It also does a NPE check in the Entity.toString(StringBuilder) method, as well as using getName instead of getSimpleName to have useful informations when using proguard.
