### PR TITLE
Add IEntity::get|setRorationOffset

### DIFF
--- a/src/org/andengine/entity/Entity.java
+++ b/src/org/andengine/entity/Entity.java
@@ -86,6 +86,7 @@ public class Entity implements IEntity {
 	protected float mHeight;
 
 	protected float mRotation = IEntity.ROTATION_DEFAULT;
+	protected float mRotationOffset = IEntity.ROTATION_OFFSET_DEFAULT;
 
 	protected float mRotationCenterX = IEntity.ROTATION_CENTER_X_DEFAULT;
 	protected float mRotationCenterY = IEntity.ROTATION_CENTER_Y_DEFAULT;
@@ -419,6 +420,16 @@ public class Entity implements IEntity {
 
 		this.mLocalToParentTransformationDirty = true;
 		this.mParentToLocalTransformationDirty = true;
+	}
+
+	@Override
+	public float getRotationOffset() {
+		return this.mRotationOffset;
+	}
+
+	@Override
+	public void setRotationOffset(final float pRotationOffset) {
+		this.mRotationOffset = pRotationOffset;
 	}
 
 	@Override
@@ -1414,6 +1425,7 @@ public class Entity implements IEntity {
 		this.mChildrenVisible = true;
 		this.mChildrenIgnoreUpdate = false;
 
+		this.mRotationOffset = IEntity.ROTATION_OFFSET_DEFAULT;
 		this.mRotation = 0;
 		this.mScaleX = 1;
 		this.mScaleY = 1;
@@ -1550,7 +1562,7 @@ public class Entity implements IEntity {
 	}
 
 	protected void applyRotation(final GLState pGLState) {
-		final float rotation = this.mRotation;
+		final float rotation = this.mRotation + this.mRotationOffset;
 
 		if (rotation != 0) {
 			final float localRotationCenterX = this.mLocalRotationCenterX;

--- a/src/org/andengine/entity/IEntity.java
+++ b/src/org/andengine/entity/IEntity.java
@@ -37,6 +37,7 @@ public interface IEntity extends IDrawHandler, IUpdateHandler, IDisposable, ITou
 	public static final float OFFSET_CENTER_Y_DEFAULT = 0.5f;
 
 	public static final float ROTATION_DEFAULT = 0;
+	public static final float ROTATION_OFFSET_DEFAULT = 0;
 	public static final float ROTATION_CENTER_X_DEFAULT = 0.5f;
 	public static final float ROTATION_CENTER_Y_DEFAULT = 0.5f;
 
@@ -115,6 +116,8 @@ public interface IEntity extends IDrawHandler, IUpdateHandler, IDisposable, ITou
 	public boolean isRotated();
 	public float getRotation();
 	public void setRotation(final float pRotation);
+	public float getRotationOffset();
+	public void setRotationOffset(final float pRotationOffset);
 
 	public float getRotationCenterX();
 	public float getRotationCenterY();

--- a/src/org/andengine/entity/scene/menu/item/decorator/BaseMenuItemDecorator.java
+++ b/src/org/andengine/entity/scene/menu/item/decorator/BaseMenuItemDecorator.java
@@ -260,6 +260,16 @@ public abstract class BaseMenuItemDecorator implements IMenuItem {
 	}
 
 	@Override
+	public float getRotationOffset() {
+		return this.mMenuItem.getRotationOffset();
+	}
+
+	@Override
+	public void setRotationOffset(final float pRotation) {
+		this.mMenuItem.setRotationOffset(pRotation);
+	}
+
+	@Override
 	public float getRotationCenterX() {
 		return this.mMenuItem.getRotationCenterX();
 	}


### PR DESCRIPTION
This change affects only how Entities are drawn. It does not modify
values returned by get|setRotation.

This is wanted since some external tools assume that Sprites' textures
can be rotated regardless of the whole Sprite's rotation 0.

It could be fixed by intoducing custom classes but this solution is much more
generic. It also seems quite safe.
