### PR TITLE
Code quality fix - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.

### DIFF
--- a/src/org/anddev/andengine/util/pool/GenericPool.java
+++ b/src/org/anddev/andengine/util/pool/GenericPool.java
@@ -1,7 +1,7 @@
 package org.anddev.andengine.util.pool;
 
 import java.util.Collections;
-import java.util.Stack;
+import java.util.Deque;
 
 import org.anddev.andengine.util.Debug;
 
@@ -24,7 +24,7 @@ public abstract class GenericPool<T> {
 	// Fields
 	// ===========================================================
 
-	private final Stack<T> mAvailableItems = new Stack<T>();
+	private final Deque<T> mAvailableItems = new LinkedList<T>();
 	private int mUnrecycledCount;
 	private final int mGrowth;
 
@@ -89,7 +89,7 @@ public abstract class GenericPool<T> {
 	}
 
 	public synchronized void batchAllocatePoolItems(final int pCount) {
-		final Stack<T> availableItems = this.mAvailableItems;
+		final Deque<T> availableItems = this.mAvailableItems;
 		for(int i = pCount - 1; i >= 0; i--) {
 			availableItems.push(this.onHandleAllocatePoolItem());
 		}
@@ -132,7 +132,7 @@ public abstract class GenericPool<T> {
 	}
 
 	public synchronized void shufflePoolItems() {
-		Collections.shuffle(this.mAvailableItems);
+		Collections.shuffle((List<T>)this.mAvailableItems);
 	}
 
 	// ===========================================================


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.

Faisal Hameed