### PR TITLE
Code quality fix - Array designators "[]" should be on the type, not the variable.

### DIFF
--- a/src/org/anddev/andengine/sensor/accelerometer/AccelerometerData.java
+++ b/src/org/anddev/andengine/sensor/accelerometer/AccelerometerData.java
@@ -19,7 +19,7 @@ public class AccelerometerData extends BaseSensorData {
 	// Constants
 	// ===========================================================
 
-	private static final IAxisSwap AXISSWAPS[] = new IAxisSwap[4];
+	private static final IAxisSwap[] AXISSWAPS = new IAxisSwap[4];
 
 	static {
 		AXISSWAPS[Surface.ROTATION_0] = new IAxisSwap() {

--- a/src/org/anddev/andengine/util/Base64.java
+++ b/src/org/anddev/andengine/util/Base64.java
@@ -178,7 +178,7 @@ public class Base64 {
 		 * Lookup table for turning bytes into their position in the
 		 * Base64 alphabet.
 		 */
-		private static final int DECODE[] = {
+		private static final int[] DECODE = {
 			-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 			-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 			-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63,
@@ -201,7 +201,7 @@ public class Base64 {
 		 * Decode lookup table for the "web safe" variant (RFC 3548
 		 * sec. 4) where - and _ replace + and /.
 		 */
-		private static final int DECODE_WEBSAFE[] = {
+		private static final int[] DECODE_WEBSAFE = {
 			-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 			-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 			-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1,
@@ -557,7 +557,7 @@ public class Base64 {
 		 * Lookup table for turning Base64 alphabet positions (6 bits)
 		 * into output bytes.
 		 */
-		private static final byte ENCODE[] = {
+		private static final byte[] ENCODE = {
 			'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
 			'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
 			'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
@@ -568,7 +568,7 @@ public class Base64 {
 		 * Lookup table for turning Base64 alphabet positions (6 bits)
 		 * into output bytes.
 		 */
-		private static final byte ENCODE_WEBSAFE[] = {
+		private static final byte[] ENCODE_WEBSAFE = {
 			'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
 			'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
 			'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',

--- a/src/org/anddev/andengine/util/ByteBufferOutputStream.java
+++ b/src/org/anddev/andengine/util/ByteBufferOutputStream.java
@@ -23,7 +23,7 @@ public class ByteBufferOutputStream extends OutputStream {
 
 	protected final int mMaximumGrow;
 
-	protected byte mData[];
+	protected byte[] mData;
 	protected int mCount;
 
 	// ===========================================================
@@ -51,7 +51,7 @@ public class ByteBufferOutputStream extends OutputStream {
 	}
 
 	@Override
-	public void write(final byte pData[], final int pOffset, final int pLength) {
+	public void write(final byte[] pData, final int pOffset, final int pLength) {
 		this.ensureCapacity(this.mCount + pLength);
 		System.arraycopy(pData, pOffset, this.mData, this.mCount, pLength);
 		this.mCount += pLength;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1197

Please let me know if you have any questions.

Faisal Hameed