### PR TITLE
Code quality fix - Useless parentheses around expressions should be removed to prevent any misunderstanding.

### DIFF
--- a/src/org/anddev/andengine/audio/sound/Sound.java
+++ b/src/org/anddev/andengine/audio/sound/Sound.java
@@ -100,7 +100,7 @@ public class Sound extends BaseAudioEntity {
 
 	@Override
 	public void setLooping(final boolean pLooping) {
-		this.setLoopCount((pLooping) ? -1 : 0);
+		this.setLoopCount(pLooping ? -1 : 0);
 	}
 
 	@Override

--- a/src/org/anddev/andengine/collision/BaseCollisionChecker.java
+++ b/src/org/anddev/andengine/collision/BaseCollisionChecker.java
@@ -33,10 +33,10 @@ public class BaseCollisionChecker {
 	// ===========================================================
 
 	public static boolean checkAxisAlignedRectangleCollision(final float pLeftA, final float pTopA, final float pRightA, final float pBottomA, final float pLeftB, final float pTopB, final float pRightB, final float pBottomB) {
-		return (pLeftA < pRightB &&
+		return  pLeftA < pRightB &&
 				pLeftB < pRightA &&
 				pTopA < pBottomB &&
-				pTopB < pBottomA);
+				pTopB < pBottomA;
 	}
 
 	/**

--- a/src/org/anddev/andengine/entity/particle/modifier/ExpireModifier.java
+++ b/src/org/anddev/andengine/entity/particle/modifier/ExpireModifier.java
@@ -64,7 +64,7 @@ public class ExpireModifier implements IParticleModifier {
 
 	@Override
 	public void onInitializeParticle(final Particle pParticle) {
-		pParticle.setDeathTime((RANDOM.nextFloat() * (this.mMaxLifeTime - this.mMinLifeTime) + this.mMinLifeTime));
+		pParticle.setDeathTime(RANDOM.nextFloat() * (this.mMaxLifeTime - this.mMinLifeTime) + this.mMinLifeTime);
 	}
 
 	@Override

--- a/src/org/anddev/andengine/entity/scene/menu/MenuScene.java
+++ b/src/org/anddev/andengine/entity/scene/menu/MenuScene.java
@@ -114,7 +114,7 @@ public class MenuScene extends CameraScene implements IOnAreaTouchListener, IOnS
 
 	@Override
 	public boolean onAreaTouched(final TouchEvent pSceneTouchEvent, final ITouchArea pTouchArea, final float pTouchAreaLocalX, final float pTouchAreaLocalY) {
-		final IMenuItem menuItem = ((IMenuItem)pTouchArea);
+		final IMenuItem menuItem = (IMenuItem)pTouchArea;
 
 		switch(pSceneTouchEvent.getAction()) {
 			case MotionEvent.ACTION_DOWN:

--- a/src/org/anddev/andengine/opengl/texture/compressed/pvr/PVRTexture.java
+++ b/src/org/anddev/andengine/opengl/texture/compressed/pvr/PVRTexture.java
@@ -31,15 +31,15 @@ public abstract class PVRTexture extends Texture {
 	// Constants
 	// ===========================================================
 
-	public static final int FLAG_MIPMAP = (1<<8); // has mip map levels
-	public static final int FLAG_TWIDDLE = (1<<9); // is twiddled
-	public static final int FLAG_BUMPMAP = (1<<10); // has normals encoded for a bump map
-	public static final int FLAG_TILING = (1<<11); // is bordered for tiled pvr
-	public static final int FLAG_CUBEMAP = (1<<12); // is a cubemap/skybox
-	public static final int FLAG_FALSEMIPCOL = (1<<13); // are there false colored MIP levels
-	public static final int FLAG_VOLUME = (1<<14); // is this a volume texture
-	public static final int FLAG_ALPHA = (1<<15); // v2.1 is there transparency info in the texture
-	public static final int FLAG_VERTICALFLIP = (1<<16); // v2.1 is the texture vertically flipped
+	public static final int FLAG_MIPMAP = 1<<; // has mip map levels
+	public static final int FLAG_TWIDDLE = 1<<9; // is twiddled
+	public static final int FLAG_BUMPMAP = 1<<10; // has normals encoded for a bump map
+	public static final int FLAG_TILING = 1<<11; // is bordered for tiled pvr
+	public static final int FLAG_CUBEMAP = 1<<12; // is a cubemap/skybox
+	public static final int FLAG_FALSEMIPCOL = 1<<13; // are there false colored MIP levels
+	public static final int FLAG_VOLUME = 1<<14; // is this a volume texture
+	public static final int FLAG_ALPHA = 1<<15; // v2.1 is there transparency info in the texture
+	public static final int FLAG_VERTICALFLIP = 1<<16; // v2.1 is the texture vertically flipped
 
 	// ===========================================================
 	// Fields

--- a/src/org/anddev/andengine/opengl/util/FastFloatBuffer.java
+++ b/src/org/anddev/andengine/opengl/util/FastFloatBuffer.java
@@ -45,7 +45,7 @@ public class FastFloatBuffer {
 	 * Constructs a new direct native-ordered buffer
 	 */
 	public FastFloatBuffer(final int pCapacity) {
-		this.mByteBuffer = ByteBuffer.allocateDirect((pCapacity * BYTES_PER_FLOAT)).order(ByteOrder.nativeOrder());
+		this.mByteBuffer = ByteBuffer.allocateDirect(pCapacity * BYTES_PER_FLOAT).order(ByteOrder.nativeOrder());
 		this.mFloatBuffer = this.mByteBuffer.asFloatBuffer();
 		this.mIntBuffer = this.mByteBuffer.asIntBuffer();
 	}

--- a/src/org/anddev/andengine/opengl/util/GLHelper.java
+++ b/src/org/anddev/andengine/opengl/util/GLHelper.java
@@ -32,7 +32,7 @@ public class GLHelper {
 	public static final int BYTES_PER_FLOAT = 4;
 	public static final int BYTES_PER_PIXEL_RGBA = 4;
 
-	private static final boolean IS_LITTLE_ENDIAN = (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN);
+	private static final boolean IS_LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
 
 	private static final int[] HARDWARETEXTUREID_CONTAINER = new int[1];
 	private static final int[] HARDWAREBUFFERID_CONTAINER = new int[1];
@@ -470,9 +470,9 @@ public class GLHelper {
 			for(int i = pPixelsARGB_8888.length - 1, j = pixelsRGB_565.length - 1; i >= 0; i--) {
 				final int pixel = pPixelsARGB_8888[i];
 
-				final int red = ((pixel >> 16) & 0xFF);
-				final int green = ((pixel >> 8) & 0xFF);
-				final int blue = ((pixel) & 0xFF);
+				final int red = (pixel >> 16) & 0xFF;
+				final int green = (pixel >> 8) & 0xFF;
+				final int blue = (pixel) & 0xFF;
 
 				/* Byte1: [R1 R2 R3 R4 R5 G1 G2 G3]
 				 * Byte2: [G4 G5 G6 B1 B2 B3 B4 B5] */
@@ -484,9 +484,9 @@ public class GLHelper {
 			for(int i = pPixelsARGB_8888.length - 1, j = pixelsRGB_565.length - 1; i >= 0; i--) {
 				final int pixel = pPixelsARGB_8888[i];
 
-				final int red = ((pixel >> 16) & 0xFF);
-				final int green = ((pixel >> 8) & 0xFF);
-				final int blue = ((pixel) & 0xFF);
+				final int red = (pixel >> 16) & 0xFF;
+				final int green = (pixel >> 8) & 0xFF;
+				final int blue = (pixel) & 0xFF;
 
 				/* Byte2: [G4 G5 G6 B1 B2 B3 B4 B5]
 				 * Byte1: [R1 R2 R3 R4 R5 G1 G2 G3]*/
@@ -504,9 +504,9 @@ public class GLHelper {
 			for(int i = pPixelsARGB_8888.length - 1, j = pixelsARGB_4444.length - 1; i >= 0; i--) {
 				final int pixel = pPixelsARGB_8888[i];
 
-				final int alpha = ((pixel >> 28) & 0x0F);
-				final int red = ((pixel >> 16) & 0xF0);
-				final int green = ((pixel >> 8) & 0xF0);
+				final int alpha = (pixel >> 28) & 0x0F;
+				final int red = (pixel >> 16) & 0xF0;
+				final int green = (pixel >> 8) & 0xF0;
 				final int blue = ((pixel) & 0x0F);
 
 				/* Byte1: [A1 A2 A3 A4 R1 R2 R3 R4]
@@ -519,10 +519,10 @@ public class GLHelper {
 			for(int i = pPixelsARGB_8888.length - 1, j = pixelsARGB_4444.length - 1; i >= 0; i--) {
 				final int pixel = pPixelsARGB_8888[i];
 
-				final int alpha = ((pixel >> 28) & 0x0F);
-				final int red = ((pixel >> 16) & 0xF0);
-				final int green = ((pixel >> 8) & 0xF0);
-				final int blue = ((pixel) & 0x0F);
+				final int alpha = (pixel >> 28) & 0x0F;
+				final int red = (pixel >> 16) & 0xF0;
+				final int green = (pixel >> 8) & 0xF0;
+				final int blue = (pixel) & 0x0F;
 
 				/* Byte2: [G1 G2 G3 G4 G2 G2 G3 G4]
 				 * Byte1: [A1 A2 A3 A4 R1 R2 R3 R4] */

--- a/src/org/anddev/andengine/util/MathUtils.java
+++ b/src/org/anddev/andengine/util/MathUtils.java
@@ -74,7 +74,7 @@ public class MathUtils implements MathConstants {
 	}
 
 	public static final boolean isPowerOfTwo(final int n) {
-		return ((n != 0) && (n & (n - 1)) == 0);
+		return (n != 0) && (n & (n - 1)) == 0;
 	}
 
 	public static final int nextPowerOfTwo(final float f) {

--- a/src/org/anddev/andengine/util/StringUtils.java
+++ b/src/org/anddev/andengine/util/StringUtils.java
@@ -86,7 +86,7 @@ public class StringUtils {
 		final int partCount = StringUtils.countOccurrences(pString, pCharacter) + 1;
 
 		final boolean reuseable = pReuse != null && pReuse.length == partCount;
-		final String[] out = (reuseable) ? pReuse : new String[partCount];
+		final String[] out = reuseable ? pReuse : new String[partCount];
 
 		if(partCount == 0) {
 			out[0] = pString;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Faisal Hameed